### PR TITLE
refactor: added multiple state tracking per reducer

### DIFF
--- a/src/Argus.Sync.Example/Reducers/TestDependencyReducer.cs
+++ b/src/Argus.Sync.Example/Reducers/TestDependencyReducer.cs
@@ -9,7 +9,7 @@ namespace Argus.Sync.Example.Reducers;
 [ReducerDepends(typeof(UtxosByAddressReducer))]
 public class TestDependencyReducer(IDbContextFactory<TestDbContext> dbContextFactory) : IReducer<TestDependency>
 {
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync();
         return await dbContext.TestDependencies.Select(td => td.Slot).FirstOrDefaultAsync();

--- a/src/Argus.Sync.Example/Reducers/UtxosByAddressReducer.cs
+++ b/src/Argus.Sync.Example/Reducers/UtxosByAddressReducer.cs
@@ -56,7 +56,7 @@ public class UtxosByAddressReducer(IDbContextFactory<TestDbContext> dbContextFac
         await dbContext.SaveChangesAsync();
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         await using TestDbContext dbContext = await dbContextFactory.CreateDbContextAsync();
         return await dbContext.UtxosByAddress.Select(e => e.Slot).FirstOrDefaultAsync();

--- a/src/Argus.Sync/Data/CardanoDbContext.cs
+++ b/src/Argus.Sync/Data/CardanoDbContext.cs
@@ -30,7 +30,7 @@ public class CardanoDbContext(
 
         modelBuilder.Entity<ReducerState>(entity =>
         {
-            entity.HasKey(e => e.Name);
+            entity.HasKey(e => new { e.Name, e.Slot });
         });
 
         modelBuilder.HasDefaultSchema(Configuration.GetConnectionString("CardanoContextSchema"));

--- a/src/Argus.Sync/Reducers/BalanceByAddressReducer.cs
+++ b/src/Argus.Sync/Reducers/BalanceByAddressReducer.cs
@@ -29,8 +29,6 @@ public class BalanceByAddressReducer<T>(IDbContextFactory<T> dbContextFactory)
             .Distinct()
             .ToList();
 
-        Expression<Func<BalanceByAddress, bool>> predicate = PredicateBuilder.False<BalanceByAddress>();
-
         List<BalanceByAddress> balanceAddressEntries = await dbContext.BalanceByAddress
             .Where(e => addresses.Contains(e.Address))
             .ToListAsync();
@@ -71,15 +69,8 @@ public class BalanceByAddressReducer<T>(IDbContextFactory<T> dbContextFactory)
             .Distinct()
             .ToList();
 
-        Expression<Func<BalanceByAddress, bool>> predicate = PredicateBuilder.False<BalanceByAddress>();
-
-        blockAddresses.ForEach(addr =>
-        {
-            predicate = predicate.Or(ba => ba.Address == addr);
-        });
-
         List<BalanceByAddress> existingAddresses = await dbContext.BalanceByAddress
-            .Where(predicate)
+            .Where(ea => blockAddresses.Contains(ea.Address))
             .ToListAsync();
 
         foreach (TransactionBody tx in block.TransactionBodies())
@@ -156,7 +147,7 @@ public class BalanceByAddressReducer<T>(IDbContextFactory<T> dbContextFactory)
         }
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.OutputBySlot.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Reducers/BlockBySlotReducer.cs
+++ b/src/Argus.Sync/Reducers/BlockBySlotReducer.cs
@@ -37,7 +37,7 @@ public class BlockBySlotReducer<T>(IDbContextFactory<T> dbContextFactory)
         await _dbContext.DisposeAsync();
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.BlockBySlot.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Reducers/IReducer.cs
+++ b/src/Argus.Sync/Reducers/IReducer.cs
@@ -7,5 +7,5 @@ public interface IReducer<out T> where T : IReducerModel
 {
     Task RollForwardAsync(Block block);
     Task RollBackwardAsync(ulong slot);
-    Task<ulong> QueryTip();
+    Task<ulong?> QueryTip();
 }

--- a/src/Argus.Sync/Reducers/JpgPriceBySubjectReducer.cs
+++ b/src/Argus.Sync/Reducers/JpgPriceBySubjectReducer.cs
@@ -181,7 +181,7 @@ public class JpgPriceBySubjectReducer<T>(
         dbContext.PriceByToken.AddRange(jpgPriceBySubjects);
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.PriceByToken.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Reducers/MinswapPriceByTokenReducer.cs
+++ b/src/Argus.Sync/Reducers/MinswapPriceByTokenReducer.cs
@@ -96,7 +96,7 @@ public class MinswapPriceByTokenReducer<T>(
         await dbContext.DisposeAsync();
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.PriceByToken.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Reducers/OutputBySlotReducer.cs
+++ b/src/Argus.Sync/Reducers/OutputBySlotReducer.cs
@@ -110,7 +110,7 @@ public class OutputBySlotReducer<T>(
         dbContext.OutputBySlot.AddRange(outputEntities);
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.OutputBySlot.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Reducers/SplashPriceByTokenReducer.cs
+++ b/src/Argus.Sync/Reducers/SplashPriceByTokenReducer.cs
@@ -101,7 +101,7 @@ public partial class SplashPriceByTokenReducer<T>(
         await dbContext.DisposeAsync();
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.PriceByToken.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Reducers/SundaePriceByTokenReducer.cs
+++ b/src/Argus.Sync/Reducers/SundaePriceByTokenReducer.cs
@@ -99,7 +99,7 @@ public class SundaePriceByTokenReducer<T>(
         await dbContext.DisposeAsync();
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.PriceByToken.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Reducers/TxBySlotReducer.cs
+++ b/src/Argus.Sync/Reducers/TxBySlotReducer.cs
@@ -50,7 +50,7 @@ public class TxBySlotReducer<T>(IDbContextFactory<T> dbContextFactory)
         await dbContext.DisposeAsync();
     }
 
-    public async Task<ulong> QueryTip()
+    public async Task<ulong?> QueryTip()
     {
         using T dbContext = await dbContextFactory.CreateDbContextAsync();
         ulong maxSlot = await dbContext.TxBySlot.MaxAsync(x => (ulong?)x.Slot) ?? 0;

--- a/src/Argus.Sync/Utils/DataUtils.cs
+++ b/src/Argus.Sync/Utils/DataUtils.cs
@@ -11,7 +11,7 @@ public static class DataUtils
 {
     public static OutputBySlot? MapTransactionOutputEntity(string transactionId, uint outputIndex, ulong slot, TransactionOutput output, UtxoStatus status)
     {
-        string? address = output.Address()!.ToBech32();
+        string? address = output.Address()!.Value.ToBech32();
 
         if (address == null)
             return null;


### PR DESCRIPTION
This pull request contains the following changes:
- Added multiple state tracking per reducer to improve rollback functionality
- Each reducer now maintains its own list of recent points 
- Now maintains a configurable rollback buffer size
- Changed QueryTip() to have a return type of nullable ulong
