### PR TITLE
fix: incorrect rollback slot passed on reducer level rollback 

### DIFF
--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Argus.Sync</PackageId>
-    <Version>0.2.8-alpha</Version>
+    <Version>0.2.9-alpha</Version>
     <Authors>clark@saib.dev</Authors>
     <Company>SAIB Inc.</Company>
     <PackageDescription>A ASP.NET Framework for Indexing Cardano Data storing it in PostgresSQL</PackageDescription>

--- a/src/Argus.Sync/Workers/CardanoIndexWorker.cs
+++ b/src/Argus.Sync/Workers/CardanoIndexWorker.cs
@@ -189,18 +189,18 @@ public class CardanoIndexWorker<T>(
         {
             RollBackType.Exclusive => response.Block!.Slot() + 1,
             RollBackType.Inclusive => response.Block!.Slot(),
-            _ => 0
+            _ => 0  
         };
-
-        var recentPoints = _reducerStates[reducerName].Points;
-
-        _reducerStates[reducerName] = (rollbackSlot, _reducerStates[reducerName].Dependencies, recentPoints);
 
         PreventMassRollback(currentSlot, rollbackSlot, reducerName, stoppingToken);
 
         // Wait for dependencies to rollback
         await AwaitReducerDependenciesRollbackAsync(reducerName, rollbackSlot, stoppingToken);
 
+        var recentPoints = _reducerStates[reducerName].Points;
+
+        _reducerStates[reducerName] = (rollbackSlot, _reducerStates[reducerName].Dependencies, recentPoints);
+        
         Stopwatch reducerStopwatch = new();
         reducerStopwatch.Start();
 


### PR DESCRIPTION
This pull request modifies the following
- instead of closest point slot being passed to the rollback function in the consumer level, the normalized rollback slot is being passed instead
- added an update in reducerStates in the rollback logic for rollback dependency problem