### PR TITLE
chore: bump version to v0.3.5-alpha

### DIFF
--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Argus.Sync</PackageId>
-    <Version>0.3.4-alpha</Version>
+    <Version>0.3.5-alpha</Version>
     <Authors>clark@saib.dev, rjlacanlaled@gmail.com</Authors>
     <Company>SAIB Inc.</Company>
     <PackageDescription>A ASP.NET Framework for Indexing Cardano Data storing it in PostgresSQL</PackageDescription>


### PR DESCRIPTION
## Summary
Bump version from `0.3.4-alpha` to `0.3.5-alpha` following recent dependency updates and Entity Framework fixes.

## Changes
- Update version in `src/Argus.Sync/Argus.Sync.csproj` from `0.3.4-alpha` to `0.3.5-alpha`

## Context
This version bump reflects the recent changes merged in PR #112:
- Updated all dependencies to latest versions
- Fixed Entity Framework version conflicts
- Improved async patterns in test code
- Removed problematic test files

🤖 Generated with [Claude Code](https://claude.ai/code)