### PR TITLE
chore: bump version to v0.3.7-alpha

### DIFF
--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Argus.Sync</PackageId>
-    <Version>0.3.6-alpha</Version>
+    <Version>0.3.7-alpha</Version>
     <Authors>clark@saib.dev, rjlacanlaled@gmail.com</Authors>
     <Company>SAIB Inc.</Company>
     <PackageDescription>A ASP.NET Framework for Indexing Cardano Data storing it in PostgresSQL</PackageDescription>


### PR DESCRIPTION
## Summary
Bump version from v0.3.6-alpha to v0.3.7-alpha

## Changes
- Updated version in `Argus.Sync.csproj`

## Reason
Following the Chrysalis update to v0.7.11 and N2C CBOR format handling fix in PR #116

🤖 Generated with [Claude Code](https://claude.ai/code)