### PR TITLE
refactor: rename ReducerDepends attribute to DependsOn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Argus implements a sophisticated dependency system that optimizes chain connecti
 
 **Dependency Declaration**:
 ```csharp
-[ReducerDepends(typeof(BlockTestReducer))]
+[DependsOn(typeof(BlockTestReducer))]
 public class DependentTransactionReducer : IReducer<TransactionTest>
 {
     // This reducer depends on BlockTestReducer
@@ -164,11 +164,11 @@ The system implements intelligent start point management to ensure dependent red
 **Declaring Dependencies**:
 ```csharp
 // Single dependency
-[ReducerDepends(typeof(BlockTestReducer))]
+[DependsOn(typeof(BlockTestReducer))]
 public class TokenReducer : IReducer<Token> { }
 
 // Chain dependency
-[ReducerDepends(typeof(TokenReducer))]
+[DependsOn(typeof(TokenReducer))]
 public class TokenStatsReducer : IReducer<TokenStats> { }
 ```
 

--- a/src/Argus.Sync.Example/Reducers/ChainedDependentReducer.cs
+++ b/src/Argus.Sync.Example/Reducers/ChainedDependentReducer.cs
@@ -7,7 +7,7 @@ using Chrysalis.Cbor.Types.Cardano.Core;
 using Microsoft.EntityFrameworkCore;
 namespace Argus.Sync.Example.Reducers;
 
-[ReducerDepends(typeof(DependentTransactionReducer))]
+[DependsOn(typeof(DependentTransactionReducer))]
 public class ChainedDependentReducer(
     IDbContextFactory<TestDbContext> dbContextFactory) : IReducer<BlockTest>
 {

--- a/src/Argus.Sync.Example/Reducers/DependentTransactionReducer.cs
+++ b/src/Argus.Sync.Example/Reducers/DependentTransactionReducer.cs
@@ -8,7 +8,7 @@ using Chrysalis.Cbor.Types.Cardano.Core;
 using Microsoft.EntityFrameworkCore;
 namespace Argus.Sync.Example.Reducers;
 
-[ReducerDepends(typeof(BlockTestReducer))]
+[DependsOn(typeof(BlockTestReducer))]
 public class DependentTransactionReducer(
     IDbContextFactory<TestDbContext> dbContextFactory) : IReducer<TransactionTest>
 {

--- a/src/Argus.Sync/Reducers/DependsOnAttribute.cs
+++ b/src/Argus.Sync/Reducers/DependsOnAttribute.cs
@@ -1,7 +1,7 @@
 namespace Argus.Sync.Reducers;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class ReducerDependsAttribute(Type dependencyType) : Attribute
+public class DependsOnAttribute(Type dependencyType) : Attribute
 {
     public Type DependencyType { get; } = dependencyType ?? throw new ArgumentNullException(nameof(dependencyType));
 }

--- a/src/Argus.Sync/Reducers/ReducerDependencyResolver.cs
+++ b/src/Argus.Sync/Reducers/ReducerDependencyResolver.cs
@@ -6,7 +6,7 @@ public static class ReducerDependencyResolver
     public static Type? GetReducerDependency(Type reducerType)
     {
         // Check if the attribute is applied to the reducerType
-        ReducerDependsAttribute? attribute = reducerType.GetCustomAttribute<ReducerDependsAttribute>();
+        DependsOnAttribute? attribute = reducerType.GetCustomAttribute<DependsOnAttribute>();
 
         // If the attribute exists, return the single dependency type
         return attribute?.DependencyType;


### PR DESCRIPTION
## Summary
- Renames `ReducerDependsAttribute` to `DependsOnAttribute` for better readability
- Updates all usages throughout the codebase
- Fixes typo in the original filename

## Changes
- Renamed `ReducerDepdendsAttribute.cs` → `DependsOnAttribute.cs`
- Updated attribute class name from `ReducerDependsAttribute` to `DependsOnAttribute`
- Updated usage in `ReducerDependencyResolver.cs`
- Updated usage in example reducers:
  - `DependentTransactionReducer.cs`
  - `ChainedDependentReducer.cs`
- Updated documentation in `CLAUDE.md`

## Note
This should be merged before the version bump PR #119

🤖 Generated with [Claude Code](https://claude.ai/code)