### PR TITLE
fix: TUI resource optimization and Chrysalis update

### DIFF
--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chrysalis" Version="0.7.11" />
+    <PackageReference Include="Chrysalis" Version="0.7.13" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Add TUI update throttling to prevent resource exhaustion during rapid sync
- Update Chrysalis to v0.7.13 which fixes LocalStateQuery returning stale data

## Changes
1. **TUI Update Throttling**
   - Implement anti-spam interval (1/4 of dashboard refresh interval)
   - Default: max 4 updates per second with 1000ms refresh interval
   - Prevents system overload during initial sync when processing hundreds of blocks/sec

2. **Chrysalis Update**
   - Update from v0.7.11 to v0.7.13
   - Fixes LocalStateQuery returning stale tip data when ChainSync is active
   - Proper state management for acquire/release cycle

3. **Architecture Improvements**
   - Store root reducer providers for potential future optimizations
   - Add `GetRootReducerName()` helper for dependency chain traversal

## Test Results
- Build successful ✅
- TUI updates properly throttled during rapid sync
- Tip queries now return current data instead of stale values

🤖 Generated with [Claude Code](https://claude.ai/code)