### PR TITLE
fix: update Chrysalis version in test project

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="0.7.11" />
+    <PackageReference Include="Chrysalis" Version="0.7.13" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Argus.Sync</PackageId>
-    <Version>0.3.8-alpha</Version>
+    <Version>0.3.9-alpha</Version>
     <Authors>clark@saib.dev, rjlacanlaled@gmail.com</Authors>
     <Company>SAIB Inc.</Company>
     <PackageDescription>A ASP.NET Framework for Indexing Cardano Data storing it in PostgresSQL</PackageDescription>


### PR DESCRIPTION
## Summary
Update Argus.Sync.Tests to use Chrysalis v0.7.13 to match the main project version.

## Problem
CI/CD was failing with:
```
error NU1605: Detected package downgrade: Chrysalis from 0.7.13 to 0.7.11
```

## Solution
- Update test project to use same Chrysalis version as main project (v0.7.13)

🤖 Generated with [Claude Code](https://claude.ai/code)