### PR TITLE
fix: update Chrysalis version in test project

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="0.7.11" />
+    <PackageReference Include="Chrysalis" Version="0.7.13" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
Update test project Chrysalis version to match main project.

## Changes
- Update Argus.Sync.Tests from Chrysalis v0.7.11 to v0.7.13

## Fixes
- Resolves CI/CD error: `NU1605: Detected package downgrade: Chrysalis from 0.7.13 to 0.7.11`

🤖 Generated with [Claude Code](https://claude.ai/code)