### PR TITLE
chore: bump version to v0.3.10-alpha

### DIFF
--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Argus.Sync</PackageId>
-    <Version>0.3.9-alpha</Version>
+    <Version>0.3.10-alpha</Version>
     <Authors>clark@saib.dev, rjlacanlaled@gmail.com</Authors>
     <Company>SAIB Inc.</Company>
     <PackageDescription>A ASP.NET Framework for Indexing Cardano Data storing it in PostgresSQL</PackageDescription>


### PR DESCRIPTION
## Summary
Bump version to v0.3.10-alpha.

## Reason
- v0.3.9-alpha was published to NuGet with incorrect build
- Skipping to v0.3.10-alpha to avoid package conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)