### PR TITLE
fix: handle SemaphoreFullException in TUI update signaling

### DIFF
--- a/src/Argus.Sync/Workers/CardanoIndexWorker.cs
+++ b/src/Argus.Sync/Workers/CardanoIndexWorker.cs
@@ -1230,9 +1230,13 @@ public class CardanoIndexWorker<T>(
         
         if (timeSinceLastUpdate >= antiSpamInterval)
         {
-            if (_tuiUpdateSignal.CurrentCount == 0)
+            try
             {
                 _tuiUpdateSignal.Release();
+            }
+            catch (SemaphoreFullException)
+            {
+                // Semaphore is already at max count, ignore
             }
             _lastTuiUpdate = DateTime.UtcNow;
         }


### PR DESCRIPTION
## Summary
Fix race condition causing SemaphoreFullException during TUI updates.

## Problem
The current implementation checks `_tuiUpdateSignal.CurrentCount == 0` before releasing, but in a multi-threaded environment, this can change between the check and the release, causing:
```
System.Threading.SemaphoreFullException: Adding the specified count to the semaphore would cause it to exceed its maximum count.
```

## Solution
- Remove the `CurrentCount` check (inherently racy in multi-threaded context)
- Use try-catch to handle `SemaphoreFullException` gracefully
- Let the semaphore handle its own state management

## Testing
- No more SemaphoreFullException errors during rapid block processing
- TUI updates continue to work with anti-spam protection

🤖 Generated with [Claude Code](https://claude.ai/code)