### PR TITLE
chore: update Chrysalis to v0.7.15

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="0.7.14" />
+    <PackageReference Include="Chrysalis" Version="0.7.15" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chrysalis" Version="0.7.14" />
+    <PackageReference Include="Chrysalis" Version="0.7.15" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Update Chrysalis to v0.7.15.

## Changes
- Update Chrysalis from v0.7.14 to v0.7.15 in Argus.Sync
- Update Chrysalis from v0.7.14 to v0.7.15 in Argus.Sync.Tests

🤖 Generated with [Claude Code](https://claude.ai/code)