### PR TITLE
chore: bump version to v0.3.14-alpha

### DIFF
--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Argus.Sync</PackageId>
-    <Version>0.3.13-alpha</Version>
+    <Version>0.3.14-alpha</Version>
     <Authors>clark@saib.dev, rjlacanlaled@gmail.com</Authors>
     <Company>SAIB Inc.</Company>
     <PackageDescription>A ASP.NET Framework for Indexing Cardano Data storing it in PostgresSQL</PackageDescription>


### PR DESCRIPTION
## Summary
- Bumps version from v0.3.13-alpha to v0.3.14-alpha
- Includes updated Chrysalis dependency v0.7.16

## Changes since v0.3.13-alpha
- chore(deps): update Chrysalis to v0.7.16 (#136)

## Test plan
- [x] Version number updated in Argus.Sync.csproj
- [ ] CI tests pass
- [ ] Ready for release tag after merge

🤖 Generated with [Claude Code](https://claude.ai/code)