### PR TITLE
chore(deps): update Chrysalis to v0.7.18

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="0.7.17" />
+    <PackageReference Include="Chrysalis" Version="0.7.18" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chrysalis" Version="0.7.17" />
+    <PackageReference Include="Chrysalis" Version="0.7.18" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Updates Chrysalis dependency from v0.7.17 to v0.7.18

## Changes
- Updated Chrysalis package reference in Argus.Sync.csproj
- Updated Chrysalis package reference in Argus.Sync.Tests.csproj

🤖 Generated with [Claude Code](https://claude.ai/code)