### PR TITLE
chore: update Chrysalis to 0.7.21

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="0.7.18" />
+    <PackageReference Include="Chrysalis" Version="0.7.21" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Argus.Sync</PackageId>
-    <Version>0.3.16-alpha</Version>
+    <Version>0.3.17-alpha</Version>
     <Authors>clark@saib.dev, rjlacanlaled@gmail.com</Authors>
     <Company>SAIB Inc.</Company>
     <PackageDescription>A ASP.NET Framework for Indexing Cardano Data storing it in PostgresSQL</PackageDescription>
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chrysalis" Version="0.7.18" />
+    <PackageReference Include="Chrysalis" Version="0.7.21" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- bump Argus.Sync package version to 0.3.17-alpha
- update Chrysalis dependency to 0.7.21 across library and test projects

## Testing
- dotnet build