### PR TITLE
chore(deps): update Chrysalis to v1.0.0-alpha

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="0.7.21" />
+    <PackageReference Include="Chrysalis" Version="1.0.0-alpha" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chrysalis" Version="0.7.21" />
+    <PackageReference Include="Chrysalis" Version="1.0.0-alpha" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Update Chrysalis dependency from `0.7.21` to `1.0.0-alpha`.

### Changes

- **Chrysalis**: `0.7.21` → `1.0.0-alpha`
- **ArgusUtil**: Removed unnecessary try-catch with `Console.WriteLine` (exceptions propagate naturally)

### Why This Matters

Chrysalis 1.0.0-alpha includes critical network error handling improvements:

| Before | After |
|--------|-------|
| Silent hangs on socket failure | Exceptions propagate immediately |
| Dead pipes block forever | Pipes complete with error state |
| No failure indication | Clear error messages |

This means Argus reducers will now properly detect and recover from network issues instead of hanging indefinitely.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)