### PR TITLE
chore(deps): update Chrysalis to v1.0.2-alpha

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="1.0.1-alpha" />
+    <PackageReference Include="Chrysalis" Version="1.0.2-alpha" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chrysalis" Version="1.0.1-alpha" />
+    <PackageReference Include="Chrysalis" Version="1.0.2-alpha" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates Chrysalis to 1.0.2-alpha

## Changes in Chrysalis 1.0.2-alpha
- Renamed Kupo provider to Kupmios (Kupo + Ogmios combined)
- Implemented transaction submission via Ogmios JSON-RPC