### PR TITLE
chore(deps): update Chrysalis to v1.0.3-alpha

### DIFF
--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Chrysalis" Version="1.0.2-alpha" />
+    <PackageReference Include="Chrysalis" Version="1.0.3-alpha" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Argus.Sync/Argus.Sync.csproj
+++ b/src/Argus.Sync/Argus.Sync.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chrysalis" Version="1.0.2-alpha" />
+    <PackageReference Include="Chrysalis" Version="1.0.3-alpha" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates Chrysalis to 1.0.3-alpha

## Changes in Chrysalis 1.0.3-alpha
- Fixed handling of empty asset names in Kupmios provider