### PR TITLE
fix(sync): remove redundant initial tip query

### DIFF
--- a/src/Argus.Sync/Workers/CardanoIndexWorker.cs
+++ b/src/Argus.Sync/Workers/CardanoIndexWorker.cs
@@ -109,9 +109,6 @@ public class CardanoIndexWorker<T>(
         
         if (!_rollbackModeEnabled)
         {
-            // Start initial tip query
-            _ = Task.Run(() => StartInitialTipQueryAsync(stoppingToken), stoppingToken);
-            
             // Start TUI dashboard if enabled
             _ = Task.Run(() => InitDashboardAsync(stoppingToken), stoppingToken);
             
@@ -1132,20 +1129,6 @@ public class CardanoIndexWorker<T>(
         }
     }
 
-    private async Task StartInitialTipQueryAsync(CancellationToken stoppingToken)
-    {
-        try
-        {
-            ICardanoChainProvider chainProvider = chainProviderFactory.CreateProvider();
-            Point initialTip = await chainProvider.GetTipAsync();
-            EffectiveTipSlot = initialTip.Slot;
-            logger.LogInformation("Initial tip established: Slot {InitialTipSlot}", initialTip.Slot);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to get initial tip");
-        }
-    }
 
     private async Task StartTelemetryAggregationAsync(CancellationToken stoppingToken)
     {


### PR DESCRIPTION
## Summary

Remove `StartInitialTipQueryAsync` which created a separate connection that conflicted with the main sync providers.

## Problem

The initial tip query created a new provider/connection that ran concurrently with the main sync providers, all connecting to the same Unix socket. This caused connection conflicts and the "Failed to get initial tip" error with `ArgumentOutOfRangeException` in the Demuxer.

## Why it's safe to remove

`EffectiveTipSlot` is already updated by multiple other code paths:
- Root providers via `GetTipAsync()` in progress tracker (line 799)
- `StartTelemetryAggregationAsync` from `_latestSlots.Values.Max()`
- `StartSyncFullDashboardTracker` from `_latestSlots.Values.Max()`

The initial tip query was just trying to get a head start on progress display, but was:
1. Redundant - other code paths update it anyway
2. Causing connection conflicts
3. Non-critical - initial progress showing 0% briefly is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)