### PR TITLE
docs + tests: 1.2 architecture README + batch-commit / N2N pipelining coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Argus is a .NET library that turns the Cardano blockchain into structured, query
 - 🧩 **Customizable reducers** — define exactly how blockchain data is processed and stored.
 - 🗄️ **Storage-agnostic** — ship on **PostgreSQL** (Entity Framework Core) or **MongoDB** out of the box; add your own backend behind one interface.
 - 🔌 **Flexible connectivity** — connect to a node via Unix socket (N2C), TCP (N2N), or gRPC/UtxoRPC (U5C).
-- ⚡ **Channel pipeline** — reducers run as a `System.Threading.Channels` graph, decoupling per-block latency from dependency depth.
+- ⚡ **Batched commits** — a root and all its dependents run as one sequential graph into a single unit of work; one transaction (one fsync) covers a whole batch of blocks, so throughput is bound by your reducer logic, not by per-block durability.
 - 🔗 **Reducer dependencies** — declare `[DependsOn(...)]` and a dependent sees its parent's writes in-process, before they're even committed.
+- 🚀 **Pipelined N2N** — node-to-node chain-sync keeps many requests in flight and batches block-fetch, so a remote peer is no longer the bottleneck.
 - 🔄 **Robust rollback handling** — chain reorganizations and operator-initiated rewinds are first-class.
 - 🛡️ **Crash-safe & single-writer** — data and checkpoint commit in one transaction; a per-database lock prevents two indexers from clobbering each other.
 - 📊 **Built-in dashboard** — track sync progress in the terminal.
@@ -56,16 +57,16 @@ Argus is a .NET library that turns the Cardano blockchain into structured, query
 | --------- | ---- |
 | **Chain Provider** | Connects to a Cardano node and streams roll-forward / roll-backward events (`N2CProvider`, `U5CProvider`, `N2NProvider`). |
 | **`CardanoIndexWorker`** | The hosted service that drives synchronization: builds the reducer dependency graph, manages connections, and feeds blocks into the pipeline. |
-| **`ReducerPipeline`** | A `System.Threading.Channels` graph mirroring your `[DependsOn]` declarations. Each reducer has a bounded inbox and its own run-loop; backpressure is automatic. |
+| **`ReducerGraphProcessor`** | One per root reducer. Runs the root and all its dependents in topological order (parents first) through a bounded `System.Threading.Channels` inbox, accumulating blocks into a batch. Backpressure is automatic. |
 | **`IReducer`** | Your transformation logic — `RollForwardAsync` / `RollBackwardAsync`. |
-| **`IBlockUnitOfWork`** | A framework-managed, per-branch transactional unit. Reducers register writes against it; the framework commits data **and** the sync checkpoint atomically. |
+| **`IBlockUnitOfWork`** | A framework-managed transactional unit shared by the whole graph for one batch. Reducers register writes against it; the framework commits all of them **and** every reducer's checkpoint together, atomically, when a batch trigger fires. |
 | **`IBlockUnitOfWorkFactory`** | The storage-backend seam. One implementation per backend (EF/Postgres, Mongo, …). |
 | **Single-instance lock** | Guarantees exactly one active indexer per database (Postgres advisory lock / Mongo lease). |
 
 **A few design points worth knowing up front:**
 
-- **The framework owns commit timing.** Reducers never call `SaveChangesAsync` (or a Mongo equivalent). You register writes through the unit of work; Argus commits your data and the reducer's checkpoint together, in one transaction, once per block per dependency branch. If anything throws, the whole branch rolls back — no partial writes.
-- **Dependents read their parent's pending writes.** Within one branch the unit of work shares a single storage handle, so a dependent reducer can see what its parent just wrote via the change-tracker's `Local` view — no DB round-trip, no stale read.
+- **The framework owns commit timing.** Reducers never call `SaveChangesAsync` (or a Mongo equivalent). You register writes through the unit of work; Argus commits your data and every reducer's checkpoint together, in one transaction, once per **batch**. A batch closes when it fills (`Sync:Commit:BatchSize`, default 500), ages out (`Sync:Commit:MaxDelayMs`, default 1000), or the inbox drains at the chain tip — so a single fsync covers many blocks while you never lag the tip. If anything throws, the **whole open batch** rolls back — no partial writes.
+- **Dependents read their parent's pending writes.** Across the graph the unit of work shares a single storage handle, so a dependent reducer can see what its parent just wrote via the change-tracker's `Local` view — no DB round-trip, no stale read.
 - **Recovery is fail-fast + restart.** Argus does not retry database faults in-process. On an unrecoverable error it stops the host; your supervisor (systemd, Kubernetes, `docker restart`) restarts the process, which resumes from the last committed checkpoint and replays. Because data and checkpoint are committed together, replay is at-least-once and idempotent.
 
 <div align="center">
@@ -245,7 +246,7 @@ app.MapGet("/api/blocks/latest", async (IDbContextFactory<MyDbContext> dbf) =>
 
 ## 🔗 Reducer Dependencies
 
-A reducer can declare a single dependency with `[DependsOn]`. Argus builds a dependency graph at startup, gives **root** reducers (no dependencies) the chain connections, and forwards blocks down to dependents through the pipeline.
+A reducer can declare a single dependency with `[DependsOn]`. Argus builds a dependency graph at startup, gives **root** reducers (no dependencies) the chain connections, and runs each block through the root and its dependents in topological order.
 
 ```csharp
 [DependsOn(typeof(BlockReducer))]
@@ -256,7 +257,7 @@ public class TransactionReducer : IReducer
         MyDbContext db = uow.GetStorage<MyDbContext>();
         ulong slot = block.Header().HeaderBody().Slot();
 
-        // BlockReducer ran first in this branch. Its pending Add() is visible here
+        // BlockReducer ran earlier in the graph. Its pending Add() is visible here
         // via the change-tracker's Local view — before it's committed to the DB.
         bool parentWroteThisBlock = db.Blocks.Local.Any(b => b.Slot == slot);
         // ... your read-modify-write logic ...
@@ -272,9 +273,9 @@ public class TransactionReducer : IReducer
 
 - **Single dependency per reducer** (prevents the diamond problem); circular dependencies are rejected at startup.
 - **Only root reducers open chain connections** — fewer connections, less node load.
-- **Linear chains share one unit of work**, so a dependent reads its parent's uncommitted writes from `Local`. At a **fork** (one parent, multiple dependents) the parent commits first and each child gets a fresh unit of work, reading the parent's now-committed data from the database.
+- **The whole graph shares one unit of work per batch.** Every reducer — root and dependents, linear chains and fan-out siblings alike — runs in topological order into the same unit of work, so any dependent reads its parent's uncommitted writes from `Local` (no DB round-trip, no stale read). There is no separate "fork" code path.
 - **Start points auto-adjust**: a fresh dependent of an already-synced parent begins at the parent's position instead of replaying from genesis.
-- **Atomicity is per-branch, not across a fork.** Each branch commits in its own transaction; a fork child failing does not roll back a sibling or the parent that already committed.
+- **Atomicity is whole-graph.** The entire graph commits in one transaction per batch; if any reducer throws, the whole open batch rolls back across **every** reducer — a sibling's writes never survive a crash that the parent or another sibling didn't.
 
 ## 💾 Storage Backends
 
@@ -374,7 +375,10 @@ On the next start every reducer rewinds to the global `Hash`/`Slot`; you can ove
 | `CardanoNodeConnection:MaxRollbackSlots` | `10000` | Maximum automatic rollback depth. |
 | `CardanoNodeConnection:RollbackBuffer` | `10` | Recent intersections retained per reducer. |
 | `CardanoIndexReducers:ActiveReducers` | (all) | Allow-list of reducer class names to run. |
-| `Sync:Pipeline:ChannelCapacity` | `256` | Bounded inbox size per reducer (backpressure). |
+| `Sync:Pipeline:ChannelCapacity` | `256` | Bounded inbox size per reducer graph (backpressure). |
+| `Sync:Commit:BatchSize` | `500` | Max blocks committed per transaction — one fsync per batch. |
+| `Sync:Commit:MaxDelayMs` | `1000` | Max time (ms) a batch stays open before committing, even if not full. |
+| `CardanoNodeConnection:TCP:PipelineDepth` | `100` | Max in-flight N2N chain-sync requests while catching up (pipelining). |
 | `Sync:SingleInstanceLock:Enabled` | `true` | Enforce one active indexer per database. |
 | `Sync:Rollback:Enabled` | `false` | Operator rollback mode (see [Rollbacks](#-rollbacks)). |
 | `Sync:Worker:ExitOnCompletion` | `true` | Exit the process when sync reaches tip (set `false` in tests). |
@@ -400,7 +404,7 @@ dotnet pack src/Argus.Sync           --configuration Release
 dotnet pack src/Argus.Sync.MongoDb   --configuration Release
 ```
 
-Integration tests run against a real preprod/preview node and a local PostgreSQL (and, for the Mongo suite, a MongoDB replica set); they self-skip when those aren't reachable. The end-to-end suite under `src/Argus.Sync.Tests/EndToEnd` exercises the worker, the dependency pipeline, per-branch atomicity, crash-recovery, the single-instance lock, and both storage backends against real Conway-era blocks.
+Integration tests run against a real preprod/preview node and a local PostgreSQL (and, for the Mongo suite, a MongoDB replica set); they self-skip when those aren't reachable. The end-to-end suite under `src/Argus.Sync.Tests/EndToEnd` exercises the worker, the dependency graph, whole-graph atomicity, batch commits, crash-recovery, N2N pipelining, the single-instance lock, and both storage backends against real Conway-era blocks.
 
 ## 📂 Project Layout
 
@@ -411,7 +415,11 @@ Integration tests run against a real preprod/preview node and a local PostgreSQL
 | `src/Argus.Sync.Example` | Runnable reference app with example models and reducers. |
 | `src/Argus.Sync.Tests` | Unit + end-to-end tests. |
 
-## 🔼 Migrating from v0.x (pre-rearchitecture)
+## 🔼 Migrating
+
+> **1.1 → 1.2:** no code changes — the reducer contract is identical. Batched whole-graph commits and pipelined N2N apply automatically. Optionally tune `Sync:Commit:BatchSize` (500), `Sync:Commit:MaxDelayMs` (1000), and `CardanoNodeConnection:TCP:PipelineDepth` (100). Durability is now per-batch: after a hard crash, up to `BatchSize` blocks replay from the last committed checkpoint (idempotent — data and checkpoint commit together).
+
+### From v0.x (pre-rearchitecture)
 
 The rearchitecture — channel pipeline, storage-agnostic unit of work, and the package split — is a major version with breaking changes. The mapping:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Argus is a .NET library that turns the Cardano blockchain into structured, query
 - **Recovery is fail-fast + restart.** Argus does not retry database faults in-process. On an unrecoverable error it stops the host; your supervisor (systemd, Kubernetes, `docker restart`) restarts the process, which resumes from the last committed checkpoint and replays. Because data and checkpoint are committed together, replay is at-least-once and idempotent.
 
 <div align="center">
-  <img src="assets/argus_architecture.png" alt="Argus Architecture" width="100%" />
+  <img src="assets/argus_architecture.svg" alt="How Argus indexes a block: a Cardano node streams blocks through CardanoIndexWorker into one batched reducer graph per root (root with nested and fan-out dependents), committing atomically to PostgreSQL or MongoDB" width="100%" />
 </div>
 
 ## 🚀 Getting Started

--- a/assets/argus_architecture.svg
+++ b/assets/argus_architecture.svg
@@ -1,0 +1,72 @@
+<svg viewBox="0 0 880 630" role="img" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif">
+  <title>How Argus indexes a block</title>
+  <desc>A Cardano node streams blocks through CardanoIndexWorker into one ReducerGraphProcessor per root. The root and its dependents — nested (A then A1) and fan-out (B) — run in topological order into a single batched unit of work, which commits to PostgreSQL or MongoDB on batch size, delay, or tip-drain.</desc>
+  <defs>
+    <marker id="a" markerWidth="9" markerHeight="9" refX="6.5" refY="3.5" orient="auto"><path d="M0,0 L8,3.5 L0,7 Z" fill="#94a3b8"/></marker>
+  </defs>
+  <rect x="2" y="2" width="876" height="626" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+
+  <text x="440" y="38" text-anchor="middle" font-size="21" font-weight="700" fill="#0f172a">How Argus indexes a block</text>
+  <text x="440" y="60" text-anchor="middle" font-size="12.5" fill="#64748b">Argus 1.2 — one batched graph per root</text>
+
+  <rect x="320" y="80" width="240" height="52" rx="11" fill="#f1f5f9" stroke="#64748b" stroke-width="1.4"/>
+  <text x="440" y="102" text-anchor="middle" font-size="14" font-weight="700" fill="#334155">Cardano node</text>
+  <text x="440" y="121" text-anchor="middle" font-size="11" fill="#64748b">N2C · N2N (pipelined) · U5C</text>
+  <line x1="440" y1="132" x2="440" y2="153" stroke="#94a3b8" stroke-width="2" marker-end="url(#a)"/>
+
+  <rect x="288" y="155" width="304" height="52" rx="11" fill="#f1f5f9" stroke="#64748b" stroke-width="1.4"/>
+  <text x="440" y="177" text-anchor="middle" font-size="14" font-weight="700" fill="#334155">CardanoIndexWorker</text>
+  <text x="440" y="196" text-anchor="middle" font-size="11" fill="#64748b">dependency graph · single-instance lock</text>
+  <line x1="440" y1="207" x2="440" y2="228" stroke="#94a3b8" stroke-width="2" marker-end="url(#a)"/>
+
+  <rect x="58" y="230" width="764" height="288" rx="15" fill="#faf5ff" stroke="#7c3aed" stroke-width="2"/>
+  <text x="80" y="258" font-size="14" font-weight="700" fill="#6d28d9">ReducerGraphProcessor <tspan font-size="11.5" font-weight="400" fill="#a78bfa">· one per root</tspan></text>
+
+  <path d="M188 322 C 222 322, 220 303, 250 303" fill="none" stroke="#c4b5fd" stroke-width="1.6"/>
+  <path d="M188 336 C 222 336, 220 371, 250 371" fill="none" stroke="#c4b5fd" stroke-width="1.6"/>
+  <line x1="366" y1="303" x2="398" y2="303" stroke="#c4b5fd" stroke-width="1.6"/>
+
+  <rect x="80" y="308" width="108" height="42" rx="9" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.3"/>
+  <text x="134" y="328" text-anchor="middle" font-size="11.5" font-weight="700" fill="#5b21b6">Root</text>
+  <text x="134" y="343" text-anchor="middle" font-size="9" fill="#a78bfa">no dependency</text>
+
+  <rect x="250" y="284" width="116" height="38" rx="9" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.3"/>
+  <text x="308" y="302" text-anchor="middle" font-size="11" font-weight="700" fill="#5b21b6">Dependent A</text>
+  <text x="308" y="315" text-anchor="middle" font-size="9" fill="#a78bfa">reads Root via .Local</text>
+
+  <rect x="398" y="284" width="116" height="38" rx="9" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.3"/>
+  <text x="456" y="302" text-anchor="middle" font-size="11" font-weight="700" fill="#5b21b6">Dependent A1</text>
+  <text x="456" y="315" text-anchor="middle" font-size="9" fill="#a78bfa">nested · reads A</text>
+
+  <rect x="250" y="352" width="116" height="38" rx="9" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.3"/>
+  <text x="308" y="370" text-anchor="middle" font-size="11" font-weight="700" fill="#5b21b6">Dependent B</text>
+  <text x="308" y="383" text-anchor="middle" font-size="9" fill="#a78bfa">fan-out · reads Root</text>
+
+  <text x="560" y="300" font-size="11" fill="#7c3aed">topological order, parents first —</text>
+  <text x="560" y="316" font-size="11" fill="#7c3aed">every reducer writes the</text>
+  <text x="560" y="332" font-size="11" fill="#7c3aed">same unit of work ↓</text>
+
+  <line x1="308" y1="398" x2="308" y2="416" stroke="#94a3b8" stroke-width="1.8" marker-end="url(#a)"/>
+
+  <rect x="80" y="418" width="720" height="82" rx="11" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="98" y="442" font-size="13" font-weight="700" fill="#5b21b6">Batched Unit of Work</text>
+  <text x="98" y="460" font-size="10.5" fill="#6d28d9">one commit per batch · whole-graph atomic · a fault rolls back the whole batch</text>
+  <rect x="98" y="469" width="98" height="23" rx="11.5" fill="#ffffff" stroke="#a78bfa" stroke-width="1.1"/>
+  <text x="147" y="484" text-anchor="middle" font-size="10" fill="#6d28d9">500 blocks</text>
+  <rect x="206" y="469" width="86" height="23" rx="11.5" fill="#ffffff" stroke="#a78bfa" stroke-width="1.1"/>
+  <text x="249" y="484" text-anchor="middle" font-size="10" fill="#6d28d9">1000 ms</text>
+  <rect x="302" y="469" width="86" height="23" rx="11.5" fill="#ffffff" stroke="#a78bfa" stroke-width="1.1"/>
+  <text x="345" y="484" text-anchor="middle" font-size="10" fill="#6d28d9">tip drain</text>
+  <text x="398" y="485" font-size="10" fill="#a78bfa">whichever fires first</text>
+
+  <line x1="440" y1="518" x2="440" y2="540" stroke="#94a3b8" stroke-width="2" marker-end="url(#a)"/>
+
+  <rect x="270" y="542" width="156" height="46" rx="11" fill="#f1f5f9" stroke="#64748b" stroke-width="1.4"/>
+  <text x="348" y="563" text-anchor="middle" font-size="12.5" font-weight="700" fill="#334155">PostgreSQL</text>
+  <text x="348" y="578" text-anchor="middle" font-size="9.5" fill="#64748b">EF Core</text>
+  <rect x="454" y="542" width="156" height="46" rx="11" fill="#f1f5f9" stroke="#64748b" stroke-width="1.4"/>
+  <text x="532" y="563" text-anchor="middle" font-size="12.5" font-weight="700" fill="#334155">MongoDB</text>
+  <text x="532" y="578" text-anchor="middle" font-size="9.5" fill="#64748b">replica set</text>
+
+  <text x="440" y="612" text-anchor="middle" font-size="10" fill="#94a3b8">Data + checkpoint commit together · restart resumes from the last checkpoint (idempotent replay).</text>
+</svg>

--- a/src/Argus.Sync.Tests/EndToEnd/N2NPipeliningLiveTest.cs
+++ b/src/Argus.Sync.Tests/EndToEnd/N2NPipeliningLiveTest.cs
@@ -1,0 +1,162 @@
+using Argus.Sync.Data.Models;
+using Argus.Sync.Providers;
+using Chrysalis.Codec.Extensions.Cardano.Core;
+using Chrysalis.Codec.Extensions.Cardano.Core.Header;
+using Chrysalis.Codec.Types.Cardano.Core;
+using Xunit.Abstractions;
+
+namespace Argus.Sync.Tests.EndToEnd;
+
+/// <summary>
+/// Live integration tests for the <b>pipelined</b> <see cref="N2NProvider"/> against a local preprod
+/// node (N2N TCP, default 3001). Complements <see cref="N2NProviderLiveTest"/> (intersection rollback
+/// + first blocks) by covering the two paths the pipelining rewrite added:
+/// <list type="number">
+///   <item>multi-batch catch-up — pulling more blocks than one pipeline depth, asserting the drain-then-
+///   fetch batches yield strictly-ascending, gap/duplicate-free full blocks across batch boundaries;</item>
+///   <item>the tip path — starting <em>at</em> the node's tip so the provider must handle
+///   <c>MessageAwaitReply</c> and then follow newly produced blocks in order, without hanging.</item>
+/// </list>
+/// Both self-skip if the N2N port is unreachable.
+/// </summary>
+public sealed class N2NPipeliningLiveTest(ITestOutputHelper output)
+{
+    private readonly ITestOutputHelper _output = output;
+
+    private const string Host = "localhost";
+    private const int Port = 3001;
+    private const ulong NetworkMagic = 1UL; // preprod
+    private const ulong IntersectionSlot = 126025608UL;
+    private const string IntersectionHash = "7ef942e6a670af6310737e9230b22e11a4bb1af69bed9affb09b1025b371d1cd";
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task PipelinedCatchUp_AcrossMultipleBatches_StrictlyAscending_NoGapsOrDuplicates()
+    {
+        if (!await IsReachableAsync(Host, Port))
+        {
+            _output.WriteLine($"SKIP: N2N port {Host}:{Port} not reachable.");
+            return;
+        }
+
+        // Depth 50 with a 150-block target guarantees the run spans more than one drain-then-fetch batch,
+        // exercising ordering + de-duplication across batch boundaries.
+        await using N2NProvider provider = new(Host, Port, PipelineDepth: 50);
+        List<Point> intersection = [new(IntersectionHash, IntersectionSlot)];
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+
+        const int target = 150;
+        List<ulong> slots = [];
+        HashSet<string> hashes = [];
+
+        try
+        {
+            await foreach (NextResponse response in provider.StartChainSyncAsync(intersection, NetworkMagic, cts.Token))
+            {
+                if (response.Action != NextResponseAction.RollForward)
+                {
+                    continue;
+                }
+                IBlock block = response.Block!;
+                slots.Add(block.Header().HeaderBody().Slot());
+                _ = hashes.Add(block.Header().Hash());
+                _ = block.TransactionBodies(); // body present + decodes (header -> BlockFetch body worked)
+                if (slots.Count >= target)
+                {
+                    break;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // window elapsed — handled by the skip below
+        }
+
+        if (slots.Count < target)
+        {
+            _output.WriteLine($"SKIP: only {slots.Count}/{target} blocks streamed (node not synced past the intersection).");
+            return;
+        }
+
+        for (int i = 1; i < slots.Count; i++)
+        {
+            Assert.True(slots[i] > slots[i - 1],
+                $"slot {slots[i]} must be strictly greater than {slots[i - 1]} (chain order, no reorder, no dupes)");
+        }
+        Assert.Equal(slots.Count, hashes.Count); // every block distinct across the batches
+        _output.WriteLine($"Pipelined {slots.Count} blocks, slots {slots[0]}..{slots[^1]} — ascending + distinct.");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task AtTip_HandlesAwaitReply_AndFollowsNewBlocksInOrder()
+    {
+        if (!await IsReachableAsync(Host, Port))
+        {
+            _output.WriteLine($"SKIP: N2N port {Host}:{Port} not reachable.");
+            return;
+        }
+
+        await using N2NProvider provider = new(Host, Port);
+        Point tip = await provider.GetTipAsync(NetworkMagic);
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(90));
+
+        NextResponse? firstRollback = null;
+        List<ulong> followed = [];
+        ulong previous = tip.Slot;
+
+        try
+        {
+            await foreach (NextResponse response in provider.StartChainSyncAsync([tip], NetworkMagic, cts.Token))
+            {
+                if (response.Action == NextResponseAction.RollBack)
+                {
+                    firstRollback ??= response;
+                }
+                else if (response.Action == NextResponseAction.RollForward)
+                {
+                    ulong slot = response.Block!.Header().HeaderBody().Slot();
+                    Assert.True(slot > previous, $"tip-follow slot {slot} must be greater than the previous {previous}");
+                    previous = slot;
+                    followed.Add(slot);
+                    if (followed.Count >= 2)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // no/slow new blocks within the window — acceptable (assertions below cover the deterministic part)
+        }
+
+        // Deterministic: starting AT the tip yields the intersection rollback, mapped Exclusive at the tip slot.
+        // Reaching this without a hang already proves the at-tip AwaitReply drain works.
+        Assert.NotNull(firstRollback);
+        Assert.Equal(RollBackType.Exclusive, firstRollback!.RollBackType);
+        Assert.Equal(tip.Slot, firstRollback.RollbackSlot);
+
+        // Best-effort: any blocks preprod produced during the window were past the tip and in order (asserted
+        // in the loop). Zero new blocks within 90s is acceptable — the tip path was still exercised.
+        _output.WriteLine(followed.Count > 0
+            ? $"At tip {tip.Slot}: followed {followed.Count} new block(s) in order: {string.Join(", ", followed)}."
+            : $"At tip {tip.Slot}: AwaitReply handled cleanly, no new block within 90s (acceptable).");
+    }
+
+    private static async Task<bool> IsReachableAsync(string host, int port)
+    {
+        try
+        {
+            using System.Net.Sockets.TcpClient client = new();
+            using CancellationTokenSource cts = new(TimeSpan.FromSeconds(2));
+            await client.ConnectAsync(host, port, cts.Token);
+            return client.Connected;
+        }
+        catch
+        {
+            // N2N port not listening -> the test skips.
+            return false;
+        }
+    }
+}

--- a/src/Argus.Sync.Tests/Unit/AdaptivePipelineDepthTest.cs
+++ b/src/Argus.Sync.Tests/Unit/AdaptivePipelineDepthTest.cs
@@ -1,0 +1,46 @@
+using Argus.Sync.Providers;
+
+namespace Argus.Sync.Tests.Unit;
+
+/// <summary>
+/// Pins <see cref="N2NProvider.AdaptivePipelineDepth"/> — the function that scales the N2N chain-sync
+/// pipeline depth by the slot-gap to the node's tip. Pure, no node required (CI-runnable). It must
+/// collapse to 1 at the tip (so we never over-request), grow with the gap, never decrease as the gap
+/// grows, and never exceed the configured maximum.
+/// </summary>
+public class AdaptivePipelineDepthTest
+{
+    [Theory]
+    [InlineData(0UL, 1)]      // at the tip -> a single in-flight request
+    [InlineData(4UL, 1)]
+    [InlineData(20UL, 2)]
+    [InlineData(100UL, 5)]
+    [InlineData(500UL, 20)]
+    [InlineData(2_000UL, 100)]
+    public void MapsTipGapToDepth_UnderAMaxOf100(ulong tipGap, int expected)
+        => Assert.Equal(expected, N2NProvider.AdaptivePipelineDepth(maxDepth: 100, tipGap));
+
+    [Fact]
+    public void FarFromTip_ClampsToTheConfiguredMax()
+    {
+        Assert.Equal(100, N2NProvider.AdaptivePipelineDepth(maxDepth: 100, tipGap: 1_000_000));
+        Assert.Equal(50, N2NProvider.AdaptivePipelineDepth(maxDepth: 50, tipGap: 1_000_000));
+        Assert.Equal(500, N2NProvider.AdaptivePipelineDepth(maxDepth: 1_000, tipGap: 10_000));
+    }
+
+    [Fact]
+    public void NeverDecreasesAsTheGapGrows()
+    {
+        int previous = 0;
+        foreach (ulong gap in new ulong[] { 0, 4, 20, 100, 500, 2_000, 10_000, 50_000, 1_000_000 })
+        {
+            int depth = N2NProvider.AdaptivePipelineDepth(maxDepth: 1_000, tipGap: gap);
+            Assert.True(depth >= previous, $"depth must be monotonic non-decreasing in the gap (gap {gap} gave {depth} < {previous})");
+            previous = depth;
+        }
+    }
+
+    [Fact]
+    public void NeverBelowOne_EvenWithATinyMax()
+        => Assert.Equal(1, N2NProvider.AdaptivePipelineDepth(maxDepth: 1, tipGap: 1_000_000));
+}

--- a/src/Argus.Sync.Tests/Unit/ReducerGraphBatchCommitTest.cs
+++ b/src/Argus.Sync.Tests/Unit/ReducerGraphBatchCommitTest.cs
@@ -1,0 +1,184 @@
+using Argus.Sync.Data.Models;
+using Argus.Sync.Reducers;
+using Argus.Sync.Tests.Mocks;
+using Argus.Sync.Workers;
+using Chrysalis.Codec.Extensions.Cardano.Core;
+using Chrysalis.Codec.Extensions.Cardano.Core.Header;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Abstractions;
+using IBlock = Chrysalis.Codec.Types.Cardano.Core.IBlock;
+
+namespace Argus.Sync.Tests.Unit;
+
+/// <summary>
+/// Drives <see cref="ReducerGraphProcessor"/> directly against the committed TestData blocks with an
+/// in-memory unit of work — no node, no database (CI-runnable). Pre-loading the inbox before
+/// <c>RunAsync</c> makes the inbox-drained trigger deterministic, so we can pin the two batch-commit
+/// behaviors the 1.2 architecture introduced: a fault rolls back the WHOLE open batch (not just the
+/// faulting block), and a partial batch commits as soon as the inbox drains (the at-tip trigger),
+/// without waiting for the size or delay triggers.
+/// </summary>
+public sealed class ReducerGraphBatchCommitTest(ITestOutputHelper output)
+{
+    private readonly ITestOutputHelper _output = output;
+
+    [Fact]
+    public async Task FaultMidBatch_RollsBackTheWholeOpenBatch_NothingCommits()
+    {
+        IBlock[] blocks = LoadBlocks(3);
+        if (blocks.Length < 3)
+        {
+            _output.WriteLine("SKIP: TestData/Blocks not present.");
+            return;
+        }
+        ulong crashSlot = blocks[2].Header().HeaderBody().Slot();
+
+        RecordingBackend backend = new();
+        ReducerGraphProcessor processor = new(
+            [new StagingReducer(), new CrashOnSlotReducer(crashSlot)],
+            new FakeUnitOfWorkFactory(backend),
+            channelCapacity: 64,
+            batchSize: 10,                            // > 3 blocks, so only the fault can end the batch
+            maxBatchDelay: TimeSpan.FromMinutes(10),  // delay trigger cannot fire in a ms-long test
+            NullLogger.Instance);
+
+        // Pre-load all three so the crashing (third) block shares ONE open batch with the first two
+        // (the inbox is never empty until the crash, so the drained trigger can't commit them early).
+        foreach (IBlock block in blocks)
+        {
+            await processor.EnqueueAsync(new NextResponse(NextResponseAction.RollForward, null, block), CancellationToken.None);
+        }
+        processor.Complete();
+
+        _ = await Assert.ThrowsAnyAsync<Exception>(() => processor.RunAsync(CancellationToken.None));
+
+        // Whole-batch atomicity: the fault discarded the open batch — none of the three blocks survived,
+        // including the two that ran cleanly before the crash.
+        Assert.Empty(backend.Committed);
+    }
+
+    [Fact]
+    public async Task DrainAtTip_CommitsAPartialBatch_WithoutWaitingForSizeOrDelay()
+    {
+        IBlock[] blocks = LoadBlocks(2);
+        if (blocks.Length < 2)
+        {
+            _output.WriteLine("SKIP: TestData/Blocks not present.");
+            return;
+        }
+
+        RecordingBackend backend = new();
+        ReducerGraphProcessor processor = new(
+            [new StagingReducer()],
+            new FakeUnitOfWorkFactory(backend),
+            channelCapacity: 64,
+            batchSize: 500,                           // far more than 2 — the size trigger cannot fire
+            maxBatchDelay: TimeSpan.FromMinutes(10),  // nor the delay trigger
+            NullLogger.Instance);
+
+        foreach (IBlock block in blocks)
+        {
+            await processor.EnqueueAsync(new NextResponse(NextResponseAction.RollForward, null, block), CancellationToken.None);
+        }
+        processor.Complete();
+        await processor.RunAsync(CancellationToken.None);
+
+        // Only the inbox-drained (at-tip) trigger could have committed — both blocks landed promptly,
+        // in chain order, despite a batch size of 500.
+        ulong[] expected = [.. blocks.Select(b => b.Header().HeaderBody().Slot())];
+        Assert.Equal(expected, backend.Committed);
+    }
+
+    private static IBlock[] LoadBlocks(int count)
+    {
+        string testDataDir = Path.Combine(Directory.GetCurrentDirectory(), "TestData");
+        if (!Directory.Exists(Path.Combine(testDataDir, "Blocks")))
+        {
+            return [];
+        }
+        MockChainSyncProvider probe = new(testDataDir);
+        return [.. probe.AvailableBlocks.Take(count)];
+    }
+
+    // ----- In-memory unit of work: reducers stage slots; a commit moves them to the durable record,
+    //       a rollback drops them. FlushAsync stays the default no-op so staged writes accumulate
+    //       across the blocks of an open batch (read-your-own-writes), exactly like the real backends. -----
+
+    private sealed class RecordingBackend
+    {
+        public List<ulong> Committed { get; } = [];
+    }
+
+    private sealed class TestStore
+    {
+        public List<ulong> Staged { get; } = [];
+    }
+
+    private sealed class FakeUnitOfWorkFactory(RecordingBackend backend) : IBlockUnitOfWorkFactory
+    {
+        public Task<IBlockUnitOfWork> CreateAsync(CancellationToken ct = default)
+            => Task.FromResult<IBlockUnitOfWork>(new FakeUnitOfWork(backend));
+
+        public Task<ReducerState?> GetReducerStateAsync(string reducerName, CancellationToken ct = default)
+            => Task.FromResult<ReducerState?>(null);
+    }
+
+    private sealed class FakeUnitOfWork(RecordingBackend backend) : IBlockUnitOfWork
+    {
+        private readonly TestStore _store = new();
+        private readonly Dictionary<string, Point> _intersections = [];
+        private bool _marked;
+
+        public T GetStorage<T>() where T : class
+            => _store as T ?? throw new InvalidCastException(typeof(T).Name);
+
+        public void TrackIntersection(string reducerName, Point point) => _intersections[reducerName] = point;
+
+        public void TrackRollback(string reducerName, ulong rollbackSlot) { }
+
+        public void MarkDataChanged() => _marked = true;
+
+        public IReadOnlyDictionary<string, Point> TrackedIntersections => _intersections;
+
+        public Task<bool> CommitAsync(bool deferIfEmpty = false, CancellationToken ct = default)
+        {
+            if (deferIfEmpty && _store.Staged.Count == 0 && !_marked)
+            {
+                return Task.FromResult(false); // empty batch — defer (no durable write)
+            }
+            backend.Committed.AddRange(_store.Staged);
+            _store.Staged.Clear();
+            _marked = false;
+            return Task.FromResult(true);
+        }
+
+        public Task RollbackAsync(CancellationToken ct = default)
+        {
+            _store.Staged.Clear();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class StagingReducer : IReducer
+    {
+        public Task RollForwardAsync(IBlock block, IBlockUnitOfWork uow, CancellationToken ct)
+        {
+            uow.GetStorage<TestStore>().Staged.Add(block.Header().HeaderBody().Slot());
+            return Task.CompletedTask;
+        }
+
+        public Task RollBackwardAsync(ulong slot, IBlockUnitOfWork uow, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class CrashOnSlotReducer(ulong crashSlot) : IReducer
+    {
+        public Task RollForwardAsync(IBlock block, IBlockUnitOfWork uow, CancellationToken ct)
+            => block.Header().HeaderBody().Slot() == crashSlot
+                ? throw new InvalidOperationException($"intentional crash at slot {crashSlot}")
+                : Task.CompletedTask;
+
+        public Task RollBackwardAsync(ulong slot, IBlockUnitOfWork uow, CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/src/Argus.Sync/Providers/N2NProvider.cs
+++ b/src/Argus.Sync/Providers/N2NProvider.cs
@@ -259,8 +259,8 @@ public class N2NProvider(string Host, int Port, int PipelineDepth = 100) : ICard
         }
     }
 
-    /// <summary>Pipeline depth as a function of the gap (in slots) to the node's tip.</summary>
-    private static int AdaptivePipelineDepth(int maxDepth, ulong tipGap)
+    /// <summary>Pipeline depth as a function of the gap (in slots) to the node's tip. Internal for unit testing.</summary>
+    internal static int AdaptivePipelineDepth(int maxDepth, ulong tipGap)
     {
         int target = tipGap switch
         {


### PR DESCRIPTION
Docs + permanent tests for the 1.2 release (the batched-graph + N2N-pipelining work shipped in #175). **For review — not merged.**

## Docs (README)

The README still described the pre-1.2 fork/pipeline model. Corrected to the shipped architecture:

- `ReducerPipeline` → `ReducerGraphProcessor` (one per root; the whole graph in topological order through one batched unit of work).
- Per-branch → **whole-graph atomicity**: one transaction per batch covers every reducer + checkpoint; a fault rolls back the whole open batch. No separate fork path.
- Documented the batch triggers (size / max-delay / drain-at-tip) and the per-batch durability/replay model.
- New keys in the config reference: `Sync:Commit:BatchSize` (500), `Sync:Commit:MaxDelayMs` (1000), `CardanoNodeConnection:TCP:PipelineDepth` (100).
- N2N marked pipelined; features list + testing blurb updated; a 1.1 → 1.2 migration note (no code changes).

## Tests

| Test | Kind | Covers |
|---|---|---|
| `AdaptivePipelineDepthTest` | CI | depth-vs-tip-gap mapping: 1 at the tip, grows with the gap, monotonic, clamped to the max |
| `ReducerGraphBatchCommitTest` | CI | whole-batch atomicity (a fault rolls back the whole open batch) + drain-at-tip (a partial batch commits without the size/delay triggers) |
| `N2NPipeliningLiveTest` | Integration | pipelined multi-batch catch-up (150 blocks, strictly ascending / no dupes) + tip-following (`AwaitReply` → follow new blocks, in order, no hang) |

The two CI tests drive `ReducerGraphProcessor` directly against the 100 committed `TestData` blocks with an in-memory unit of work — deterministic (the inbox is pre-loaded so the drain trigger is predictable) and free of any node or database. `AdaptivePipelineDepth` was made `internal` so the unit test can call it.

**Validation:** `dotnet format` clean, 22/22 non-integration tests, both live N2N tests pass against the local preprod node.

## Note

`assets/argus_architecture.png` still depicts the old pipeline — I can't regenerate the image, so the diagram is worth refreshing separately if you want it to match the prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
