### PR TITLE
refactor(ef): split EntityFramework into a provider-neutral core + Postgres package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: |
           mkdir -p out
-          for proj in src/Argus.Sync/Argus.Sync.csproj src/Argus.Sync.EntityFramework/Argus.Sync.EntityFramework.csproj src/Argus.Sync.MongoDb/Argus.Sync.MongoDb.csproj; do
+          for proj in src/Argus.Sync/Argus.Sync.csproj src/Argus.Sync.EntityFramework/Argus.Sync.EntityFramework.csproj src/Argus.Sync.EntityFramework.Postgres/Argus.Sync.EntityFramework.Postgres.csproj src/Argus.Sync.MongoDb/Argus.Sync.MongoDb.csproj; do
             echo "Packing $proj..."
             dotnet pack "$proj" -c Release -o out
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           V="${{ steps.version.outputs.version }}"
           dotnet pack src/Argus.Sync/Argus.Sync.csproj -c Release -o out -p:Version="$V"
           dotnet pack src/Argus.Sync.EntityFramework/Argus.Sync.EntityFramework.csproj -c Release -o out -p:Version="$V"
+          dotnet pack src/Argus.Sync.EntityFramework.Postgres/Argus.Sync.EntityFramework.Postgres.csproj -c Release -o out -p:Version="$V"
           dotnet pack src/Argus.Sync.MongoDb/Argus.Sync.MongoDb.csproj -c Release -o out -p:Version="$V"
 
       - name: Push to NuGet

--- a/Argus.slnx
+++ b/Argus.slnx
@@ -1,6 +1,9 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Argus.Sync/Argus.Sync.csproj" />
+    <Project Path="src/Argus.Sync.EntityFramework/Argus.Sync.EntityFramework.csproj" />
+    <Project Path="src/Argus.Sync.EntityFramework.Postgres/Argus.Sync.EntityFramework.Postgres.csproj" />
+    <Project Path="src/Argus.Sync.MongoDb/Argus.Sync.MongoDb.csproj" />
     <Project Path="src/Argus.Sync.Example/Argus.Sync.Example.csproj" />
     <Project Path="src/Argus.Sync.Tests/Argus.Sync.Tests.csproj" />
     <Project Path="src/Argus.Sync.Bench/Argus.Sync.Bench.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,26 +9,26 @@
     <PackageVersion Include="Utxorpc.Sdk" Version="1.7.0-alpha" />
 
     <!-- Microsoft Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 
     <!-- Database -->
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
     <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
 
     <!-- UI / API -->
-    <PackageVersion Include="Spectre.Console" Version="0.53.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.5" />
+    <PackageVersion Include="Spectre.Console" Version="0.57.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.2" />
 
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
 
     <!-- Benchmarking -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/README.md
+++ b/README.md
@@ -82,9 +82,8 @@ Argus is a .NET library that turns the Cardano blockchain into structured, query
 dotnet add package Argus.Sync
 
 # PostgreSQL backend (Entity Framework Core) + EF tooling for migrations
-dotnet add package Argus.Sync.EntityFramework
+dotnet add package Argus.Sync.EntityFramework.Postgres   # pulls in the provider-neutral Argus.Sync.EntityFramework core + Npgsql
 dotnet add package Microsoft.EntityFrameworkCore.Design
-dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
 
 # Or, instead: MongoDB backend
 dotnet add package Argus.Sync.MongoDb
@@ -201,8 +200,8 @@ public class BlockReducer : IReducer
 ### 6️⃣ Register services
 
 ```csharp
-using Argus.Sync.EntityFramework;   // AddCardanoPostgresIndexer + CardanoDbContext
-using Argus.Sync.Extensions;        // AddReducers
+using Argus.Sync.EntityFramework.Postgres;  // AddCardanoPostgresIndexer
+using Argus.Sync.Extensions;                // AddReducers
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -285,9 +284,11 @@ A backend is one implementation of `IBlockUnitOfWorkFactory` (create a batched t
 
 ### PostgreSQL (Entity Framework Core)
 
-Add the `Argus.Sync.EntityFramework` package. Your `CardanoDbContext`-derived context *is* the storage handle:
+Add the `Argus.Sync.EntityFramework.Postgres` package (it brings in the provider-neutral `Argus.Sync.EntityFramework` core). Your `CardanoDbContext`-derived context *is* the storage handle:
 
 ```csharp
+using Argus.Sync.EntityFramework.Postgres;
+
 builder.Services.AddCardanoPostgresIndexer<MyDbContext>(builder.Configuration);
 builder.Services.AddReducers(builder.Configuration);
 ```
@@ -402,9 +403,10 @@ dotnet test
 dotnet test --filter "Category!=Integration"
 
 # Pack the NuGet packages
-dotnet pack src/Argus.Sync                 --configuration Release
-dotnet pack src/Argus.Sync.EntityFramework --configuration Release
-dotnet pack src/Argus.Sync.MongoDb         --configuration Release
+dotnet pack src/Argus.Sync                          --configuration Release
+dotnet pack src/Argus.Sync.EntityFramework          --configuration Release
+dotnet pack src/Argus.Sync.EntityFramework.Postgres --configuration Release
+dotnet pack src/Argus.Sync.MongoDb                  --configuration Release
 ```
 
 Integration tests run against a real preprod/preview node and a local PostgreSQL (and, for the Mongo suite, a MongoDB replica set); they self-skip when those aren't reachable. The end-to-end suite under `src/Argus.Sync.Tests/EndToEnd` exercises the worker, the dependency graph, whole-graph atomicity, batch commits, crash-recovery, N2N pipelining, the single-instance lock, and both storage backends against real Conway-era blocks.
@@ -414,7 +416,8 @@ Integration tests run against a real preprod/preview node and a local PostgreSQL
 | Project | Purpose |
 | ------- | ------- |
 | `src/Argus.Sync` | Core library (storage-agnostic): worker, reducer graph, unit-of-work seam, chain providers. |
-| `src/Argus.Sync.EntityFramework` | PostgreSQL / EF Core backend (`AddCardanoPostgresIndexer`, `CardanoDbContext`). |
+| `src/Argus.Sync.EntityFramework` | Provider-neutral EF Core backend (`CardanoDbContext`, EF unit-of-work, the `AddCardanoEntityFrameworkIndexer` seam). |
+| `src/Argus.Sync.EntityFramework.Postgres` | PostgreSQL / Npgsql provider (`AddCardanoPostgresIndexer`, advisory single-instance lock). |
 | `src/Argus.Sync.MongoDb` | MongoDB storage backend (`AddCardanoMongoIndexer`). |
 | `src/Argus.Sync.Example` | Runnable reference app with example models and reducers. |
 | `src/Argus.Sync.Tests` | Unit + end-to-end tests. |
@@ -434,15 +437,15 @@ The rearchitecture — channel pipeline, storage-agnostic unit of work, and the 
 | `RollBackwardAsync` | `RollBackwardAsync(ulong slot)` | `RollBackwardAsync(ulong slot, IBlockUnitOfWork uow, CancellationToken ct)` |
 | Block type | `Block` (`Chrysalis.Cbor.Types…`) | `IBlock` (`Chrysalis.Codec.Types.Cardano.Core`) |
 | Data access | inject `IDbContextFactory<T>`; call `db.SaveChangesAsync()` | `uow.GetStorage<T>()`; the framework commits — **never** call `SaveChangesAsync` |
-| Postgres registration | `AddCardanoIndexer<T>()` (core package) | `AddCardanoPostgresIndexer<T>()` from the **`Argus.Sync.EntityFramework`** package |
+| Postgres registration | `AddCardanoIndexer<T>()` (core package) | `AddCardanoPostgresIndexer<T>()` from the **`Argus.Sync.EntityFramework.Postgres`** package |
 | Reducer registration | `AddReducers<T, V>(config)` | `AddReducers(config)` (non-generic) |
-| Packages | `Argus.Sync` (EF baked in) | `Argus.Sync` (core) **+** `Argus.Sync.EntityFramework` (Postgres) or `Argus.Sync.MongoDb` |
+| Packages | `Argus.Sync` (EF baked in) | `Argus.Sync` (core) **+** `Argus.Sync.EntityFramework.Postgres` or `Argus.Sync.MongoDb` |
 | `IReducerModel` | marker interface | now requires `ulong Slot { get; }` |
 | Rollback-mode config | `CardanoIndexReducers:RollbackMode:*` | `Sync:Rollback:*` |
 | Removed config | `Sync:State:ReducerStateSyncInterval` | gone |
 | N2N (TCP) provider | not implemented | supported (`ConnectionType: "TCP"`) |
 
-**To upgrade a reducer in practice:** drop the `IDbContextFactory` constructor parameter and the `<T>` on `IReducer`; change both methods to take `(…, IBlockUnitOfWork uow, CancellationToken ct)`; replace `dbContextFactory.CreateDbContext()` with `uow.GetStorage<YourDbContext>()`; and delete every `SaveChangesAsync` call. Then add the `Argus.Sync.EntityFramework` package reference, and switch `AddCardanoIndexer<T>` → `AddCardanoPostgresIndexer<T>` and `AddReducers<T, V>` → `AddReducers`.
+**To upgrade a reducer in practice:** drop the `IDbContextFactory` constructor parameter and the `<T>` on `IReducer`; change both methods to take `(…, IBlockUnitOfWork uow, CancellationToken ct)`; replace `dbContextFactory.CreateDbContext()` with `uow.GetStorage<YourDbContext>()`; and delete every `SaveChangesAsync` call. Then add the `Argus.Sync.EntityFramework.Postgres` package reference, and switch `AddCardanoIndexer<T>` → `AddCardanoPostgresIndexer<T>` and `AddReducers<T, V>` → `AddReducers`.
 
 ## 🤝 Contributing
 

--- a/src/Argus.Sync.EntityFramework.Postgres/Argus.Sync.EntityFramework.Postgres.csproj
+++ b/src/Argus.Sync.EntityFramework.Postgres/Argus.Sync.EntityFramework.Postgres.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Argus.Sync.EntityFramework.Postgres</PackageId>
+    <Authors>clark@saib.dev</Authors>
+    <Company>SAIB Inc.</Company>
+    <PackageDescription>PostgreSQL / Npgsql provider for the Argus.Sync Entity Framework Core backend — the AddCardanoPostgresIndexer entry point and its Postgres advisory single-instance lock, layered over the provider-neutral Argus.Sync.EntityFramework core.</PackageDescription>
+    <RepositoryUrl>https://github.com/SAIB-Inc/Argus</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Argus.Sync.EntityFramework\Argus.Sync.EntityFramework.csproj" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+  </ItemGroup>
+
+</Project>

--- a/src/Argus.Sync.EntityFramework.Postgres/PostgresServiceCollectionExtensions.cs
+++ b/src/Argus.Sync.EntityFramework.Postgres/PostgresServiceCollectionExtensions.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using Argus.Sync.Providers;
+using Argus.Sync.Workers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Argus.Sync.EntityFramework.Postgres;
+
+/// <summary>
+/// Dependency-injection entry point for running the Cardano indexer on the PostgreSQL / Npgsql backend.
+/// Call <see cref="AddCardanoPostgresIndexer{T}"/> with your <see cref="CardanoDbContext"/>-derived context,
+/// then <c>AddReducers</c>. This is a thin Npgsql wrapper over the provider-neutral
+/// <see cref="EfServiceCollectionExtensions.AddCardanoEntityFrameworkIndexer{T}"/>: it supplies the
+/// <c>UseNpgsql</c> provider and registers a Postgres session-advisory single-instance lock.
+/// </summary>
+public static class PostgresServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Cardano indexer on the EF Core / PostgreSQL backend: an Npgsql-backed DbContext factory,
+    /// the EF unit-of-work factory (data + checkpoint storage), a Postgres single-instance advisory lock, the
+    /// chain-provider factory, and the indexer worker as a hosted service.
+    /// </summary>
+    /// <typeparam name="T">The database context type inheriting from <see cref="CardanoDbContext"/>.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <param name="commandTimeout">The database command timeout in seconds.</param>
+    /// <param name="chainProviderFactory">An optional custom chain provider factory; defaults to configuration-based if null.</param>
+    /// <returns>The service collection for method chaining.</returns>
+    public static IServiceCollection AddCardanoPostgresIndexer<T>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        int commandTimeout = 60,
+        IChainProviderFactory? chainProviderFactory = null) where T : CardanoDbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Postgres single-instance guard (advisory lock): ONE shared singleton, exposed both as
+        // ISingleInstanceLock (the indexer's gate) and as a hosted service (runs the acquire/hold/release loop).
+        // The factory indirection keeps both roles on the SAME instance. Opt out via Sync:SingleInstanceLock:Enabled=false.
+        if (configuration.GetValue("Sync:SingleInstanceLock:Enabled", true))
+        {
+            _ = services.AddSingleton<PostgresSingleInstanceLock>();
+            _ = services.AddSingleton<ISingleInstanceLock>(sp => sp.GetRequiredService<PostgresSingleInstanceLock>());
+            _ = services.AddHostedService(sp => sp.GetRequiredService<PostgresSingleInstanceLock>());
+        }
+
+        return services.AddCardanoEntityFrameworkIndexer<T>(
+            configuration,
+            options =>
+            {
+                Assembly? contextAssembly = typeof(T).Assembly;
+
+                // EnableRetryOnFailure is intentionally NOT configured: EF's retrying execution strategy throws on
+                // user-initiated transactions not wrapped in CreateExecutionStrategy().ExecuteAsync(...), and the
+                // per-block-branch transaction spans multiple pipeline tasks (and captures raw ExecuteUpdate/SQL),
+                // so it cannot be a single retriable delegate. Transient faults are recovered out-of-process via
+                // fail-fast + restart + checkpoint-resume — see AddCardanoEntityFrameworkIndexer's remarks.
+                _ = options.UseNpgsql(
+                    configuration.GetConnectionString("CardanoContext"),
+                    x =>
+                    {
+                        _ = x.MigrationsAssembly(contextAssembly!.FullName);
+                        _ = x.CommandTimeout(commandTimeout);
+                        _ = x.MigrationsHistoryTable("__EFMigrationsHistory", configuration.GetConnectionString("CardanoContextSchema"));
+                    });
+            },
+            chainProviderFactory);
+    }
+}

--- a/src/Argus.Sync.EntityFramework.Postgres/PostgresSingleInstanceLock.cs
+++ b/src/Argus.Sync.EntityFramework.Postgres/PostgresSingleInstanceLock.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
-namespace Argus.Sync.EntityFramework;
+namespace Argus.Sync.EntityFramework.Postgres;
 
 /// <summary>
 /// <see cref="BackgroundService"/> that holds a Postgres <em>session-level advisory lock</em>
@@ -25,21 +25,21 @@ namespace Argus.Sync.EntityFramework;
 /// <para>Requires a session-pinned connection: behind PgBouncer use session-pooling mode, not
 /// transaction-pooling, or the session advisory lock will not persist across statements.</para>
 /// </remarks>
-public sealed partial class PostgresSingleInstanceLockWorker : BackgroundService, ISingleInstanceLock
+public sealed partial class PostgresSingleInstanceLock : BackgroundService, ISingleInstanceLock
 {
     private readonly string _connectionString;
     private readonly long _key;
     private readonly TimeSpan _pollInterval;
     private readonly TimeSpan _healthInterval;
-    private readonly ILogger<PostgresSingleInstanceLockWorker> _logger;
+    private readonly ILogger<PostgresSingleInstanceLock> _logger;
     private readonly IHostApplicationLifetime _lifetime;
     private readonly TaskCompletionSource _acquired = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private NpgsqlConnection? _connection;
 
     /// <summary>Creates the lock worker from configuration (connection string, schema, intervals).</summary>
-    public PostgresSingleInstanceLockWorker(
+    public PostgresSingleInstanceLock(
         IConfiguration configuration,
-        ILogger<PostgresSingleInstanceLockWorker> logger,
+        ILogger<PostgresSingleInstanceLock> logger,
         IHostApplicationLifetime lifetime)
     {
         ArgumentNullException.ThrowIfNull(configuration);

--- a/src/Argus.Sync.EntityFramework/Argus.Sync.EntityFramework.csproj
+++ b/src/Argus.Sync.EntityFramework/Argus.Sync.EntityFramework.csproj
@@ -4,13 +4,13 @@
     <PackageId>Argus.Sync.EntityFramework</PackageId>
     <Authors>clark@saib.dev</Authors>
     <Company>SAIB Inc.</Company>
-    <PackageDescription>Entity Framework Core (PostgreSQL / Npgsql) storage backend for Argus.Sync — the AddCardanoPostgresIndexer entry point and its EF unit-of-work, DbContext base, and advisory-lock.</PackageDescription>
+    <PackageDescription>Provider-neutral Entity Framework Core storage backend for Argus.Sync — the EF unit-of-work, DbContext base, and the AddCardanoEntityFrameworkIndexer registration seam. Pair with a provider package such as Argus.Sync.EntityFramework.Postgres.</PackageDescription>
     <RepositoryUrl>https://github.com/SAIB-Inc/Argus</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Argus.Sync\Argus.Sync.csproj" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
   </ItemGroup>
 
 </Project>

--- a/src/Argus.Sync.EntityFramework/CardanoDbContext.cs
+++ b/src/Argus.Sync.EntityFramework/CardanoDbContext.cs
@@ -8,7 +8,7 @@ namespace Argus.Sync.EntityFramework;
 /// <summary>
 /// Base database context for EF Core consumers. Inherit from this to colocate
 /// your reducer-data tables with the framework's <see cref="ReducerState"/>
-/// table in a single Postgres schema. Non-EF consumers do not need this type;
+/// table in a single database schema. Non-EF consumers do not need this type;
 /// implement <see cref="Reducers.IBlockUnitOfWorkFactory"/> directly instead.
 /// </summary>
 /// <param name="Options">The database context options.</param>

--- a/src/Argus.Sync.EntityFramework/EfBlockUnitOfWorkFactory.cs
+++ b/src/Argus.Sync.EntityFramework/EfBlockUnitOfWorkFactory.cs
@@ -2,6 +2,7 @@ using Argus.Sync.Data;
 using Argus.Sync.Data.Models;
 using Argus.Sync.Reducers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Configuration;
 
 namespace Argus.Sync.EntityFramework;
@@ -38,7 +39,7 @@ public sealed class EfBlockUnitOfWorkFactory<TContext> : IBlockUnitOfWorkFactory
     public async Task<IBlockUnitOfWork> CreateAsync(CancellationToken ct = default)
     {
         TContext dbContext = await _dbContextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
-        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction =
+        IDbContextTransaction transaction =
             await dbContext.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
         return new EfBlockUnitOfWork<TContext>(dbContext, transaction, _rollbackBuffer);
     }

--- a/src/Argus.Sync.EntityFramework/EfServiceCollectionExtensions.cs
+++ b/src/Argus.Sync.EntityFramework/EfServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
-using System.Reflection;
 using Argus.Sync.Extensions;
 using Argus.Sync.Providers;
 using Argus.Sync.Reducers;
-using Argus.Sync.Workers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,30 +8,35 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Argus.Sync.EntityFramework;
 
 /// <summary>
-/// Dependency-injection entry point for running the Cardano indexer on the Entity Framework Core /
-/// PostgreSQL backend. Call <see cref="AddCardanoPostgresIndexer{T}"/> with your
-/// <see cref="CardanoDbContext"/>-derived context, then <c>AddReducers</c>. The Postgres counterpart of
-/// <c>AddCardanoMongoIndexer</c>; both register their backend-specific storage seam and then share
-/// <c>AddCardanoIndexerCore</c> from the core <c>Argus.Sync</c> library.
+/// Dependency-injection entry point for running the Cardano indexer on a provider-neutral Entity
+/// Framework Core backend. A provider package supplies the concrete EF provider via
+/// <c>configureProvider</c> and registers its own single-instance lock, then calls
+/// <see cref="AddCardanoEntityFrameworkIndexer{T}"/> — for example <c>AddCardanoPostgresIndexer</c>
+/// from <c>Argus.Sync.EntityFramework.Postgres</c>. Both this and the Mongo backend register their
+/// backend-specific storage seam and then share <c>AddCardanoIndexerCore</c> from the core
+/// <c>Argus.Sync</c> library.
 /// </summary>
 public static class EfServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the Cardano indexer on the EF Core / PostgreSQL backend: a pooled DbContext factory, the EF
-    /// unit-of-work factory (data + checkpoint storage), a Postgres single-instance advisory lock, the
-    /// chain-provider factory, and the indexer worker as a hosted service.
+    /// Registers the Cardano indexer on a provider-neutral EF Core backend: a DbContext factory (configured
+    /// by <paramref name="configureProvider"/>), the EF unit-of-work factory (data + checkpoint storage), the
+    /// chain-provider factory, and the indexer worker as a hosted service. It does <b>not</b> register a
+    /// single-instance lock — a provider package adds the lock appropriate to its database (e.g. a Postgres
+    /// session advisory lock) before calling this.
     /// </summary>
     /// <remarks>
     /// <para><b>Transient-fault recovery.</b> Argus does not retry database faults in-process. EF Core's
     /// <c>EnableRetryOnFailure</c> execution strategy hard-throws on user-initiated transactions, and Argus
     /// opens one manual transaction per block-branch (it spans multiple pipeline tasks and captures raw
     /// <c>ExecuteUpdate</c>/SQL atomically) — a unit that cannot be expressed as a single retriable delegate.
-    /// See the <c>UseNpgsql</c> note below. Recovery is fail-fast and crash-safe instead:</para>
+    /// Provider registrations therefore do not enable a retrying execution strategy. Recovery is fail-fast and
+    /// crash-safe instead:</para>
     /// <list type="number">
     /// <item>A fault while processing a block rolls that block-branch's transaction back atomically — no partial
     /// writes (tracked rows, raw SQL, and the reducer-state checkpoint all roll back together).</item>
-    /// <item>The fault propagates out of <see cref="CardanoIndexWorker"/>'s execute loop, which stops the host
-    /// (the default <see cref="Microsoft.Extensions.Hosting.BackgroundService"/> behavior).</item>
+    /// <item>The fault propagates out of <see cref="Workers.CardanoIndexWorker"/>'s execute loop,
+    /// which stops the host (the default <see cref="Microsoft.Extensions.Hosting.BackgroundService"/> behavior).</item>
     /// <item>An external supervisor (systemd, Kubernetes, Docker <c>restart:</c>) restarts the process, which
     /// resumes from the last atomically-committed checkpoint and replays the failed block.</item>
     /// </list>
@@ -43,50 +46,24 @@ public static class EfServiceCollectionExtensions
     /// <typeparam name="T">The database context type inheriting from <see cref="CardanoDbContext"/>.</typeparam>
     /// <param name="services">The service collection.</param>
     /// <param name="configuration">The application configuration.</param>
-    /// <param name="commandTimout">The database command timeout in seconds.</param>
+    /// <param name="configureProvider">Configures the EF Core provider on the DbContext options (e.g. <c>o =&gt; o.UseNpgsql(...)</c>).</param>
     /// <param name="chainProviderFactory">An optional custom chain provider factory; defaults to configuration-based if null.</param>
     /// <returns>The service collection for method chaining.</returns>
-    public static IServiceCollection AddCardanoPostgresIndexer<T>(
+    public static IServiceCollection AddCardanoEntityFrameworkIndexer<T>(
         this IServiceCollection services,
         IConfiguration configuration,
-        int commandTimout = 60,
+        Action<DbContextOptionsBuilder> configureProvider,
         IChainProviderFactory? chainProviderFactory = null) where T : CardanoDbContext
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(configureProvider);
 
-        _ = services.AddDbContextFactory<T>(options =>
-        {
-            Assembly? contextAssembly = typeof(T).Assembly;
-
-            // EnableRetryOnFailure is intentionally NOT configured: EF's retrying execution strategy throws on
-            // user-initiated transactions not wrapped in CreateExecutionStrategy().ExecuteAsync(...), and the
-            // per-block-branch transaction spans multiple pipeline tasks (and captures raw ExecuteUpdate/SQL),
-            // so it cannot be a single retriable delegate. Transient faults are recovered out-of-process via
-            // fail-fast + restart + checkpoint-resume — see the remarks above.
-            _ = options.UseNpgsql(
-                configuration.GetConnectionString("CardanoContext"),
-                x =>
-                {
-                    _ = x.MigrationsAssembly(contextAssembly!.FullName);
-                    _ = x.CommandTimeout(commandTimout);
-                    _ = x.MigrationsHistoryTable("__EFMigrationsHistory", configuration!.GetConnectionString("CardanoContextSchema"));
-                });
-        });
+        _ = services.AddDbContextFactory<T>(configureProvider);
 
         // EF unit-of-work factory — the storage-backend seam: transactional per-branch units + checkpoint reads.
         _ = services.AddSingleton<IBlockUnitOfWorkFactory>(sp =>
             new EfBlockUnitOfWorkFactory<T>(sp.GetRequiredService<IDbContextFactory<T>>(), configuration));
-
-        // Postgres single-instance guard (advisory lock): ONE shared singleton, exposed both as
-        // ISingleInstanceLock (the indexer's gate) and as a hosted service (runs the acquire/hold/release loop).
-        // The factory indirection keeps both roles on the SAME instance. Opt out via Sync:SingleInstanceLock:Enabled=false.
-        if (configuration.GetValue("Sync:SingleInstanceLock:Enabled", true))
-        {
-            _ = services.AddSingleton<PostgresSingleInstanceLockWorker>();
-            _ = services.AddSingleton<ISingleInstanceLock>(sp => sp.GetRequiredService<PostgresSingleInstanceLockWorker>());
-            _ = services.AddHostedService(sp => sp.GetRequiredService<PostgresSingleInstanceLockWorker>());
-        }
 
         return services.AddCardanoIndexerCore(chainProviderFactory);
     }

--- a/src/Argus.Sync.Example/Argus.Sync.Example.csproj
+++ b/src/Argus.Sync.Example/Argus.Sync.Example.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Argus.Sync\Argus.Sync.csproj" />
     <ProjectReference Include="..\Argus.Sync.EntityFramework\Argus.Sync.EntityFramework.csproj" />
+    <ProjectReference Include="..\Argus.Sync.EntityFramework.Postgres\Argus.Sync.EntityFramework.Postgres.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Argus.Sync.Example/Program.cs
+++ b/src/Argus.Sync.Example/Program.cs
@@ -1,4 +1,4 @@
-using Argus.Sync.EntityFramework;
+using Argus.Sync.EntityFramework.Postgres;
 using Argus.Sync.Example.Data;
 using Argus.Sync.Example.Services;
 using Argus.Sync.Extensions;

--- a/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
+++ b/src/Argus.Sync.Tests/Argus.Sync.Tests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Argus.Sync\Argus.Sync.csproj" />
     <ProjectReference Include="..\Argus.Sync.EntityFramework\Argus.Sync.EntityFramework.csproj" />
+    <ProjectReference Include="..\Argus.Sync.EntityFramework.Postgres\Argus.Sync.EntityFramework.Postgres.csproj" />
     <ProjectReference Include="..\Argus.Sync.Example\Argus.Sync.Example.csproj" />
     <ProjectReference Include="..\Argus.Sync.MongoDb\Argus.Sync.MongoDb.csproj" />
   </ItemGroup>

--- a/src/Argus.Sync.Tests/EndToEnd/IndexerRegistrationTest.cs
+++ b/src/Argus.Sync.Tests/EndToEnd/IndexerRegistrationTest.cs
@@ -1,4 +1,5 @@
 using Argus.Sync.EntityFramework;
+using Argus.Sync.EntityFramework.Postgres;
 using Argus.Sync.Example.Data;
 using Argus.Sync.MongoDb;
 using Argus.Sync.Reducers;
@@ -53,7 +54,7 @@ public sealed class IndexerRegistrationTest
 
         // The lock is the Postgres advisory lock, shared across both roles.
         ISingleInstanceLock gate = provider.GetRequiredService<ISingleInstanceLock>();
-        PostgresSingleInstanceLockWorker concrete = provider.GetRequiredService<PostgresSingleInstanceLockWorker>();
+        PostgresSingleInstanceLock concrete = provider.GetRequiredService<PostgresSingleInstanceLock>();
         Assert.Same(concrete, gate);
 
         AssertWorkerHosted(services);

--- a/src/Argus.Sync.Tests/EndToEnd/SingleInstanceLockTest.cs
+++ b/src/Argus.Sync.Tests/EndToEnd/SingleInstanceLockTest.cs
@@ -1,4 +1,4 @@
-using Argus.Sync.EntityFramework;
+using Argus.Sync.EntityFramework.Postgres;
 using Argus.Sync.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -48,8 +48,8 @@ public sealed class SingleInstanceLockTest(ITestOutputHelper output) : IAsyncLif
         using ILoggerFactory loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
         FakeLifetime lifetime = new();
 
-        using PostgresSingleInstanceLockWorker first = CreateWorker(loggerFactory, lifetime);
-        using PostgresSingleInstanceLockWorker second = CreateWorker(loggerFactory, lifetime);
+        using PostgresSingleInstanceLock first = CreateWorker(loggerFactory, lifetime);
+        using PostgresSingleInstanceLock second = CreateWorker(loggerFactory, lifetime);
 
         // 1. First instance starts and acquires the (uncontended) lock.
         await first.StartAsync(CancellationToken.None);
@@ -74,7 +74,7 @@ public sealed class SingleInstanceLockTest(ITestOutputHelper output) : IAsyncLif
         Assert.False(lifetime.StopCalled, "the host should never be asked to stop in the happy path");
     }
 
-    private PostgresSingleInstanceLockWorker CreateWorker(ILoggerFactory loggerFactory, IHostApplicationLifetime lifetime)
+    private PostgresSingleInstanceLock CreateWorker(ILoggerFactory loggerFactory, IHostApplicationLifetime lifetime)
     {
         // Both workers point at the same test database → same lock key → they contend.
         IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
@@ -84,9 +84,9 @@ public sealed class SingleInstanceLockTest(ITestOutputHelper output) : IAsyncLif
             ["Sync:SingleInstanceLock:HealthCheckSeconds"] = "1",
         }).Build();
 
-        return new PostgresSingleInstanceLockWorker(
+        return new PostgresSingleInstanceLock(
             config,
-            loggerFactory.CreateLogger<PostgresSingleInstanceLockWorker>(),
+            loggerFactory.CreateLogger<PostgresSingleInstanceLock>(),
             lifetime);
     }
 


### PR DESCRIPTION
## What

Splits `Argus.Sync.EntityFramework` into the EF Core ecosystem's shape — a **provider-neutral core** plus a **per-provider package** — and refreshes dependencies along the way. Two commits:

1. **`chore(deps)`** — refresh NuGet packages to latest within the net10 line (Microsoft.Extensions.* + EF Core trio → 10.0.9, Npgsql.EFCore → 10.0.2, AspNetCore.OpenApi → 10.0.9, Swashbuckle → 10.2.2, Spectre.Console → 0.57.0, Test.Sdk → 18.6.0, coverlet → 10.0.1). `xunit` stays on 2.x (no v3 migration); Chrysalis/Utxorpc alpha pins untouched.
2. **`refactor(ef)`** — the package split (below).

## The split

| Package | Role | Depends on |
| --- | --- | --- |
| `Argus.Sync.EntityFramework` | **Provider-neutral** EF Core backend: `CardanoDbContext`, the EF unit-of-work, and the new public `AddCardanoEntityFrameworkIndexer<T>(configureProvider)` seam | `Argus.Sync` + `Microsoft.EntityFrameworkCore.Relational` |
| `Argus.Sync.EntityFramework.Postgres` *(new)* | PostgreSQL / Npgsql provider: `AddCardanoPostgresIndexer<T>` (a thin `UseNpgsql` wrapper) + the advisory single-instance lock | `Argus.Sync.EntityFramework` + `Npgsql.EntityFrameworkCore.PostgreSQL` |

`AddCardanoPostgresIndexer` is now a small wrapper that (1) builds the `UseNpgsql` delegate, (2) registers the Postgres lock, (3) calls the core seam. Adding SQLite/SQL Server later is a sibling wrapper over the same seam — this lands the **structural half of #178**.

The advisory-lock worker is renamed `PostgresSingleInstanceLockWorker` → `PostgresSingleInstanceLock` to match the sibling `MongoSingleInstanceLock` (git tracked it as a rename).

## ⚠️ Breaking

Consumers of `AddCardanoPostgresIndexer` must now:
- add the **`Argus.Sync.EntityFramework.Postgres`** package (it pulls in the core transitively), and
- add `using Argus.Sync.EntityFramework.Postgres;`.

Acceptable in alpha; suggests a notable bump (e.g. **v1.3.0-alpha**) at release. The pm2 stability consumers will need the new package on their next bump (not touched here).

## Also

- Fix the `commandTimout` → `commandTimeout` typo on the public registration.
- Make the core docs provider-neutral ("Postgres schema" → "database schema", etc.).
- Wire the new package into the Example, Tests (`IndexerRegistrationTest`, `SingleInstanceLockTest`), the `release.yml` + `ci.yml` pack lists, and the README.

## Verification

- ✅ `dotnet build -c Release` — 0 warnings, 0 errors.
- ✅ `dotnet format --verify-no-changes` — clean.
- ✅ `dotnet test --filter "Category!=Integration&Category!=DataGeneration"` — **22 passed**; `IndexerRegistrationTest` proves `AddCardanoPostgresIndexer` still wires the EF seam + renamed lock + worker.
- ✅ `dotnet pack` both EF packages — nuspecs confirm core → `Microsoft.EntityFrameworkCore.Relational` (no Npgsql); Postgres → `Argus.Sync.EntityFramework` + Npgsql.

## Out of scope

No new provider (SQLite/etc.) and no generic lease-lock — the remaining half of #178 (each non-Postgres provider needs its own `ISingleInstanceLock`). The `CardanoNodeConnection:RollbackBuffer` key is unchanged (consistent with Mongo + the live consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
