### PR TITLE
chore(deps): bump Chrysalis to 1.7.13-alpha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
               - 'src/**'
               - '*.slnx'
               - 'Directory.Build.props'
+              - 'Directory.Packages.props'
               - '.github/workflows/ci.yml'
 
       - name: Setup .NET

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <!-- Blockchain -->
-    <PackageVersion Include="Chrysalis" Version="1.7.12-alpha" />
+    <PackageVersion Include="Chrysalis" Version="1.7.13-alpha" />
     <PackageVersion Include="Utxorpc.Sdk" Version="1.7.0-alpha" />
 
     <!-- Microsoft Extensions -->


### PR DESCRIPTION
Bumps `Chrysalis` 1.7.12-alpha → 1.7.13-alpha — picks up [SAIB-Inc/Chrysalis#379](https://github.com/SAIB-Inc/Chrysalis/pull/379) (use the chain cost model for node-exact ExUnits).

Verified locally: `dotnet build -c Release` 0 warnings / 0 errors, 22 non-integration tests pass, `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)